### PR TITLE
Added multiple sexp support and expanded msg formatting parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+$ cat .gitignore
+
+# Can ignore specific files
+.DS_Store
+
+# Use wildcards as well
+*~
+*.fasl
+*#
+*.#
+.#*
+
+# Can also ignore all directories and files in a directory.
+xdb2/
+


### PR DESCRIPTION
1. read-eval-print returns multiple values from "(list 123) (list 321)"
2. and returns a syntax error message for "(list 123" instead of ";;No values".
3. also added more formatting parameters to get control of how output from read-eval-print is formatted.